### PR TITLE
fix assigning the index of beampatterns_spatialfilter->gains

### DIFF
--- a/src/init/directivity.c
+++ b/src/init/directivity.c
@@ -196,7 +196,7 @@
                     iThetaFilter = nThetasFilter - 1;
                 }                
 
-                gainFilter = beampatterns_spatialfilter->gains[iThetaFilter];
+                gainFilter = beampatterns_spatialfilter->gains[iFilter * nThetasFilter + iThetaFilter];
 
                 gainFilters *= gainFilter;
 


### PR DESCRIPTION
## Summary
I tried to set more than one spatial filter, but it doesn't seem to work properly.
In the source code, only the first gains of the spatial filters ware used, so I have fixed.

## Before Fix
### example 1: dual case
```
    spatialfilters = (
        {
            direction = ( +0.000, +0.000, +1.000 );
            angle = (90.0, 110.0);
        },
        {
            direction = ( +0.000, +0.000, -1.000 );
            angle = (150.0, 160.0);
        }
    );
```
### example 1: ODAS Studio
![dual_case_wrong](https://user-images.githubusercontent.com/49263408/60419340-02b7d780-9c20-11e9-9b3c-bec66df0a61a.png)

### example 2: dual case (flipped order)
```
    spatialfilters = (
        {
            direction = ( +0.000, +0.000, -1.000 );
            angle = (150.0, 160.0);
        },
        {
            direction = ( +0.000, +0.000, +1.000 );
            angle = (90.0, 110.0);
        }
    );
```
### example 2:  ODAS Studio
![dual_case_flipped_wrong](https://user-images.githubusercontent.com/49263408/60419503-67733200-9c20-11e9-9f7a-fb6f2643ebea.png)

## After Fix
### example 1: dual case
```
    spatialfilters = (
        {
            direction = ( +0.000, +0.000, +1.000 );
            angle = (90.0, 110.0);
        },
        {
            direction = ( +0.000, +0.000, -1.000 );
            angle = (150.0, 160.0);
        }
    );
```
### example 1: ODAS Studio
![dual_case_fixed](https://user-images.githubusercontent.com/49263408/60419558-8671c400-9c20-11e9-80c3-d24736fa527b.png)
