### PR TITLE
Implement interface_socket for source_hops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build
+bin
+lib
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 bin
 lib
 .vscode
+*.raw

--- a/include/odas/source/src_hops.h
+++ b/include/odas/source/src_hops.h
@@ -1,105 +1,116 @@
 #ifndef __ODAS_SOURCE_HOPS
 #define __ODAS_SOURCE_HOPS
 
-   /**
-    * \file     src_hops.h
-    * \author   François Grondin <francois.grondin2@usherbrooke.ca>
-    * \version  2.0
-    * \date     2018-03-18
-    * \copyright
-    *
-    * This program is free software: you can redistribute it and/or modify
-    * it under the terms of the GNU General Public License as published by
-    * the Free Software Foundation, either version 3 of the License, or
-    * (at your option) any later version.
-    *
-    * This program is distributed in the hope that it will be useful,
-    * but WITHOUT ANY WARRANTY; without even the implied warranty of
-    * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    * GNU General Public License for more details.
-    * 
-    * You should have received a copy of the GNU General Public License
-    * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-    *
-    */
+/**
+ * \file     src_hops.h
+ * \author   François Grondin <francois.grondin2@usherbrooke.ca>
+ * \version  2.0
+ * \date     2018-03-18
+ * \copyright
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
-    #include <stdlib.h>
-    #include <stdio.h>
-    #include <string.h>
-    #include <alsa/asoundlib.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <alsa/asoundlib.h>
 
-    #include "../general/format.h"
-    #include "../general/interface.h"
-    #include "../message/msg_hops.h"
-    #include "../signal/hop.h"
-    #include "../utils/pcm.h"
+#include "../general/format.h"
+#include "../general/interface.h"
+#include "../message/msg_hops.h"
+#include "../signal/hop.h"
+#include "../utils/pcm.h"
 
-    typedef struct src_hops_obj {
+typedef struct src_hops_obj
+{
 
-        unsigned long long timeStamp;
+    unsigned long long timeStamp;
 
-        unsigned int hopSize;
-        unsigned int nChannels;
-        unsigned int fS;
+    unsigned int hopSize;
+    unsigned int nChannels;
+    unsigned int fS;
 
-        format_obj * format;
-        interface_obj * interface;
+    format_obj *format;
+    interface_obj *interface;
 
-        FILE * fp;
-        snd_pcm_t * ch;
+    FILE *fp;
+    snd_pcm_t *ch;
+    struct sockaddr_in sserver;
+    int sid;
 
-        char * buffer;
-        unsigned int bufferSize;
+    char *buffer;
+    unsigned int bufferSize;
 
-        char bytes[4];
+    char bytes[4];
 
-        msg_hops_obj * out;
+    msg_hops_obj *out;
 
-    } src_hops_obj;
+} src_hops_obj;
 
-    typedef struct src_hops_cfg {
+typedef struct src_hops_cfg
+{
 
-        format_obj * format;
-        interface_obj * interface;
+    format_obj *format;
+    interface_obj *interface;
 
-    } src_hops_cfg;
+} src_hops_cfg;
 
-    src_hops_obj * src_hops_construct(const src_hops_cfg * src_hops_config, const msg_hops_cfg * msg_hops_config);
+src_hops_obj *src_hops_construct(const src_hops_cfg *src_hops_config, const msg_hops_cfg *msg_hops_config);
 
-    void src_hops_destroy(src_hops_obj * obj);
+void src_hops_destroy(src_hops_obj *obj);
 
-    void src_hops_connect(src_hops_obj * obj, msg_hops_obj * out);
+void src_hops_connect(src_hops_obj *obj, msg_hops_obj *out);
 
-    void src_hops_disconnect(src_hops_obj * obj);
+void src_hops_disconnect(src_hops_obj *obj);
 
-    void src_hops_open(src_hops_obj * obj);
+void src_hops_open(src_hops_obj *obj);
 
-    void src_hops_open_interface_file(src_hops_obj * obj);
+void src_hops_open_interface_file(src_hops_obj *obj);
 
-    void src_hops_open_interface_soundcard(src_hops_obj * obj);
+void src_hops_open_interface_soundcard(src_hops_obj *obj);
 
-    void src_hops_close(src_hops_obj * obj);
+void src_hops_open_interface_socket(src_hops_obj *obj);
 
-    void src_hops_close_interface_file(src_hops_obj * obj);
+void src_hops_close(src_hops_obj *obj);
 
-    void src_hops_close_interface_soundcard(src_hops_obj * obj);
+void src_hops_close_interface_file(src_hops_obj *obj);
 
-    int src_hops_process(src_hops_obj * obj);
+void src_hops_close_interface_soundcard(src_hops_obj *obj);
 
-    int src_hops_process_interface_file(src_hops_obj * obj);
+int src_hops_process(src_hops_obj *obj);
 
-    int src_hops_process_interface_soundcard(src_hops_obj * obj);
+int src_hops_process_interface_file(src_hops_obj *obj);
 
-    void src_hops_process_format_binary_int08(src_hops_obj * obj);
+int src_hops_process_interface_soundcard(src_hops_obj *obj);
 
-    void src_hops_process_format_binary_int16(src_hops_obj * obj);
+int src_hops_process_interface_socket(src_hops_obj *obj);
 
-    void src_hops_process_format_binary_int24(src_hops_obj * obj);
+void src_hops_process_format_binary_int08(src_hops_obj *obj);
 
-    void src_hops_process_format_binary_int32(src_hops_obj * obj);
+void src_hops_process_format_binary_int16(src_hops_obj *obj);
 
-    src_hops_cfg * src_hops_cfg_construct(void);
+void src_hops_process_format_binary_int24(src_hops_obj *obj);
 
-    void src_hops_cfg_destroy(src_hops_cfg * src_hops_config);
+void src_hops_process_format_binary_int32(src_hops_obj *obj);
+
+src_hops_cfg *src_hops_cfg_construct(void);
+
+void src_hops_cfg_destroy(src_hops_cfg *src_hops_config);
 
 #endif

--- a/include/odas/source/src_hops.h
+++ b/include/odas/source/src_hops.h
@@ -93,6 +93,8 @@ void src_hops_close_interface_file(src_hops_obj *obj);
 
 void src_hops_close_interface_soundcard(src_hops_obj *obj);
 
+void src_hops_close_interface_socket(src_hops_obj *obj);
+
 int src_hops_process(src_hops_obj *obj);
 
 int src_hops_process_interface_file(src_hops_obj *obj);

--- a/re6_sockets.cfg
+++ b/re6_sockets.cfg
@@ -10,14 +10,14 @@ raw:
 
     fS = 16000;
     hopSize = 128;
-    nBits = 32;
+    nBits = 16;
     nChannels = 8; 
 
     # Input with raw signal from microphones
     interface: {
         type = "socket";
-        ip = "192.168.0.9";
-        port = 9000;
+        ip = "192.168.0.243";
+        port = 12346;
 
         # type = "soundcard";
         # card = 1;
@@ -31,7 +31,8 @@ raw:
 mapping:
 {
 
-    map: (1, 2, 3, 4, 5, 6);
+    # 5 and 6 are skipped for some reason
+    map: (1, 2, 3, 4, 7, 8);
 
 }
 
@@ -166,14 +167,16 @@ ssl:
     # Output to export potential sources
     potential: {
 
-        format = "undefined";
-        # format = "json";
+        # format = "undefined";
+        # interface: {
+        #     type = "blackhole";
+        # }
 
+        format = "json";
         interface: {
-            type = "blackhole";
-            # type = "socket"; ip = "127.0.0.1"; port = 9001;
+            # type = "terminal";
+            type = "socket"; ip = "172.25.112.1"; port = 9001;
         };
-
 
     };
 
@@ -246,14 +249,16 @@ sst:
     # Output to export tracked sources
     tracked: {
 
-        format = "undefined";
-        # format = "json";
+        # format = "undefined";
+        # interface: {
+        #     type = "blackhole";
+        # }
 
+        format = "json";
         interface: {
-            type = "blackhole";
-            # type = "socket"; ip = "127.0.0.1"; port = 9000;
+            # type = "terminal";
+            type = "socket"; ip = "172.25.112.1"; port = 9000;
         };
-
 
     };
 

--- a/re6_sockets.cfg
+++ b/re6_sockets.cfg
@@ -1,0 +1,362 @@
+# Configuration file for ReSpeaker 6 Mic Array
+# Circular shape, R = 0.0463m
+
+version = "2.1";
+
+# Raw
+
+raw: 
+{
+
+    fS = 16000;
+    hopSize = 128;
+    nBits = 32;
+    nChannels = 8; 
+
+    # Input with raw signal from microphones
+    interface: {
+        type = "socket";
+        ip = "192.168.0.9";
+        port = 9000;
+
+        # type = "soundcard";
+        # card = 1;
+        # device = 0;
+    }
+
+}
+
+# Mapping
+
+mapping:
+{
+
+    map: (1, 2, 3, 4, 5, 6);
+
+}
+
+# General
+
+general:
+{
+    
+    epsilon = 1E-20;
+
+    size: 
+    {
+        hopSize = 128;
+        frameSize = 256;
+    };
+    
+    samplerate:
+    {
+        mu = 16000;
+        sigma2 = 0.01;
+    };
+
+    speedofsound:
+    {
+        mu = 343.0;
+        sigma2 = 25.0;
+    };
+
+    mics = (
+        
+        # Microphone 1
+        { 
+            mu = ( -0.0232, +0.0401, +0.0000 ); 
+            sigma2 = ( +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000 );
+            direction = ( +0.000, +0.000, +1.000 );
+            angle = ( 80.0, 90.0 );
+        },
+
+        # Microphone 2
+        { 
+            mu = ( -0.0463, +0.0000, +0.0000 ); 
+            sigma2 = ( +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000 );
+            direction = ( +0.000, +0.000, +1.000 );
+            angle = ( 80.0, 90.0 );
+        },
+
+        # Microphone 3
+        { 
+            mu = ( -0.0232, -0.0401, +0.0000 ); 
+            sigma2 = ( +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000 );
+            direction = ( +0.000, +0.000, +1.000 );
+            angle = ( 80.0, 90.0 );
+        },
+
+        # Microphone 4
+        { 
+            mu = ( +0.0232, -0.0401, +0.0000 ); 
+            sigma2 = ( +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000 );
+            direction = ( +0.000, +0.000, +1.000 );
+            angle = ( 80.0, 90.0 );        
+        },
+
+        # Microphone 5
+        { 
+            mu = ( +0.0463, +0.0000, +0.0000 ); 
+            sigma2 = ( +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000 );
+            direction = ( +0.000, +0.000, +1.000 );
+            angle = ( 80.0, 90.0 );        
+        },
+
+        # Microphone 6
+        { 
+            mu = ( +0.0232, +0.0401, +0.0000 ); 
+            sigma2 = ( +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000 );
+            direction = ( +0.000, +0.000, +1.000 );
+            angle = ( 80.0, 90.0 );
+        }
+        
+    );
+
+    # Spatial filters to include only a range of direction if required
+    # (may be useful to remove false detections from the floor, or
+    # limit the space search to a restricted region)
+    spatialfilters = (
+
+        {
+
+            direction = ( +0.000, +0.000, +1.000 );
+            angle = (80.0, 90.0);
+
+        }
+
+    );  
+
+    nThetas = 181;
+    gainMin = 0.25;
+
+};
+
+# Stationnary noise estimation
+
+sne:
+{
+    
+    b = 3;
+    alphaS = 0.1;
+    L = 150;
+    delta = 3.0;
+    alphaD = 0.1;
+
+}
+
+# Sound Source Localization
+
+ssl:
+{
+
+    nPots = 4;
+    nMatches = 10;
+    probMin = 0.5;
+    nRefinedLevels = 1;
+    interpRate = 4;
+
+    # Number of scans: level is the resolution of the sphere
+    # and delta is the size of the maximum sliding window
+    # (delta = -1 means the size is automatically computed)
+    scans = (
+        { level = 2; delta = -1; },
+        { level = 4; delta = -1; }
+    );
+
+    # Output to export potential sources
+    potential: {
+
+        format = "undefined";
+        # format = "json";
+
+        interface: {
+            type = "blackhole";
+            # type = "socket"; ip = "127.0.0.1"; port = 9001;
+        };
+
+
+    };
+
+};
+
+# Sound Source Tracking
+
+sst:
+{  
+
+    # Mode is either "kalman" or "particle"
+
+    mode = "kalman";
+
+    # Add is either "static" or "dynamic"
+
+    add = "dynamic";
+
+    # Parameters used by both the Kalman and particle filter
+
+    active = (
+        { weight = 1.0; mu = 0.3; sigma2 = 0.0025 }
+    );
+
+    inactive = (
+        { weight = 1.0; mu = 0.15; sigma2 = 0.0025 }
+    );
+
+    sigmaR2_prob = 0.0025;
+    sigmaR2_active = 0.0225;
+    sigmaR2_target = 0.0025;
+    Pfalse = 0.1;
+    Pnew = 0.1;
+    Ptrack = 0.8;
+
+    theta_new = 0.9;
+    N_prob = 5;
+    theta_prob = 0.8;
+    N_inactive = ( 150, 200, 250, 250 );
+    theta_inactive = 0.9;
+
+    # Parameters used by the Kalman filter only
+
+    kalman: {
+
+        sigmaQ = 0.001;
+        
+    };
+   
+    # Parameters used by the particle filter only
+
+    particle: {
+
+        nParticles = 1000;
+        st_alpha = 2.0;
+        st_beta = 0.04;
+        st_ratio = 0.5;
+        ve_alpha = 0.05;
+        ve_beta = 0.2;
+        ve_ratio = 0.3;
+        ac_alpha = 0.5;
+        ac_beta = 0.2;
+        ac_ratio = 0.2;
+        Nmin = 0.7;
+
+    };
+
+    target: ();
+
+    # Output to export tracked sources
+    tracked: {
+
+        format = "undefined";
+        # format = "json";
+
+        interface: {
+            type = "blackhole";
+            # type = "socket"; ip = "127.0.0.1"; port = 9000;
+        };
+
+
+    };
+
+}
+
+sss:
+{
+    
+    # Mode is either "dds", "dgss" or "dmvdr"
+
+    mode_sep = "dds";
+    mode_pf = "ms";
+
+    gain_sep = 1.0;
+    gain_pf = 10.0;
+
+    dds: {
+
+    };
+
+    dgss: {
+
+        mu = 0.01;
+        lambda = 0.5;
+
+    };
+
+    dmvdr: {
+
+    };
+
+    ms: {
+
+        alphaPmin = 0.07;
+        eta = 0.5;
+        alphaZ = 0.8;        
+        thetaWin = 0.3;
+        alphaWin = 0.3;
+        maxAbsenceProb = 0.9;
+        Gmin = 0.01;
+        winSizeLocal = 3;
+        winSizeGlobal = 23;
+        winSizeFrame = 256;
+
+    };
+
+    ss: {
+
+        Gmin = 0.01;
+        Gmid = 0.9;
+        Gslope = 10.0;
+
+    }
+
+    separated: {
+
+        fS = 44100;
+        hopSize = 512;
+        nBits = 16;        
+
+        interface: {
+            type = "file";
+            path = "separated.raw";
+        }        
+
+    };
+
+    postfiltered: {
+
+        fS = 44100;
+        hopSize = 512;
+        nBits = 16;        
+
+        interface: {
+            type = "file";
+            path = "postfiltered.raw";
+        }        
+
+    };
+
+}
+
+classify:
+{
+    
+    frameSize = 1024;
+    winSize = 3;
+    tauMin = 32;
+    tauMax = 200;
+    deltaTauMax = 7;
+    alpha = 0.3;
+    gamma = 0.05;
+    phiMin = 0.15;
+    r0 = 0.2;    
+
+    category: {
+
+        format = "undefined";
+
+        interface: {
+            type = "blackhole";
+        }
+
+    }
+
+}

--- a/re6_vr.cfg
+++ b/re6_vr.cfg
@@ -1,0 +1,369 @@
+# Configuration file for ReSpeaker 6 Mic Array
+# Circular shape, R = 0.0463m
+
+version = "2.1";
+
+# Raw
+
+raw: 
+{
+
+    fS = 16000;
+    hopSize = 128;
+    nBits = 16;
+    nChannels = 8; 
+
+    # Input with raw signal from microphones
+    interface: {
+        type = "socket";
+        # This should be the Pi IP
+        ip = "192.168.0.243";
+        port = 12346;
+
+        # type = "soundcard";
+        # card = 1;
+        # device = 0;
+    }
+
+}
+
+# Mapping
+
+mapping:
+{
+
+    # 5 and 6 are skipped for some reason
+    map: (1, 2, 3, 4, 7, 8);
+
+}
+
+# General
+
+general:
+{
+    
+    epsilon = 1E-20;
+
+    size: 
+    {
+        hopSize = 128;
+        frameSize = 256;
+    };
+    
+    samplerate:
+    {
+        mu = 16000;
+        sigma2 = 0.01;
+    };
+
+    speedofsound:
+    {
+        mu = 343.0;
+        sigma2 = 25.0;
+    };
+
+    mics = (
+        
+        # Microphone 1
+        { 
+            mu = ( -0.0232, +0.0401, +0.0000 ); 
+            sigma2 = ( +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000 );
+            direction = ( +0.000, +0.000, +1.000 );
+            angle = ( 80.0, 90.0 );
+        },
+
+        # Microphone 2
+        { 
+            mu = ( -0.0463, +0.0000, +0.0000 ); 
+            sigma2 = ( +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000 );
+            direction = ( +0.000, +0.000, +1.000 );
+            angle = ( 80.0, 90.0 );
+        },
+
+        # Microphone 3
+        { 
+            mu = ( -0.0232, -0.0401, +0.0000 ); 
+            sigma2 = ( +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000 );
+            direction = ( +0.000, +0.000, +1.000 );
+            angle = ( 80.0, 90.0 );
+        },
+
+        # Microphone 4
+        { 
+            mu = ( +0.0232, -0.0401, +0.0000 ); 
+            sigma2 = ( +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000 );
+            direction = ( +0.000, +0.000, +1.000 );
+            angle = ( 80.0, 90.0 );        
+        },
+
+        # Microphone 5
+        { 
+            mu = ( +0.0463, +0.0000, +0.0000 ); 
+            sigma2 = ( +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000 );
+            direction = ( +0.000, +0.000, +1.000 );
+            angle = ( 80.0, 90.0 );        
+        },
+
+        # Microphone 6
+        { 
+            mu = ( +0.0232, +0.0401, +0.0000 ); 
+            sigma2 = ( +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000, +0.000 );
+            direction = ( +0.000, +0.000, +1.000 );
+            angle = ( 80.0, 90.0 );
+        }
+        
+    );
+
+    # Spatial filters to include only a range of direction if required
+    # (may be useful to remove false detections from the floor, or
+    # limit the space search to a restricted region)
+    spatialfilters = (
+
+        {
+
+            direction = ( +0.000, +0.000, +1.000 );
+            angle = (80.0, 90.0);
+
+        }
+
+    );  
+
+    nThetas = 181;
+    gainMin = 0.25;
+
+};
+
+# Stationnary noise estimation
+
+sne:
+{
+    
+    b = 3;
+    alphaS = 0.1;
+    L = 150;
+    delta = 3.0;
+    alphaD = 0.1;
+
+}
+
+# Sound Source Localization
+
+ssl:
+{
+
+    nPots = 4;
+    nMatches = 10;
+    probMin = 0.5;
+    nRefinedLevels = 1;
+    interpRate = 4;
+
+    # Number of scans: level is the resolution of the sphere
+    # and delta is the size of the maximum sliding window
+    # (delta = -1 means the size is automatically computed)
+    scans = (
+        { level = 2; delta = -1; },
+        { level = 4; delta = -1; }
+    );
+
+    # Output to export potential sources
+    potential: {
+
+        # format = "undefined";
+        # interface: {
+        #     type = "blackhole";
+        # }
+
+        format = "json";
+        interface: {
+            # type = "terminal";
+            # This should be the Windows IP
+            type = "socket"; ip = "172.24.48.1"; port = 10000;
+        };
+
+    };
+
+};
+
+# Sound Source Tracking
+
+sst:
+{  
+
+    # Mode is either "kalman" or "particle"
+
+    mode = "kalman";
+
+    # Add is either "static" or "dynamic"
+
+    add = "dynamic";
+
+    # Parameters used by both the Kalman and particle filter
+
+    active = (
+        { weight = 1.0; mu = 0.3; sigma2 = 0.0025 }
+    );
+
+    inactive = (
+        { weight = 1.0; mu = 0.15; sigma2 = 0.0025 }
+    );
+
+    sigmaR2_prob = 0.0025;
+    sigmaR2_active = 0.0225;
+    sigmaR2_target = 0.0025;
+    Pfalse = 0.1;
+    Pnew = 0.1;
+    Ptrack = 0.8;
+
+    theta_new = 0.9;
+    N_prob = 5;
+    theta_prob = 0.8;
+    N_inactive = ( 150, 200, 250, 250 );
+    theta_inactive = 0.9;
+
+    # Parameters used by the Kalman filter only
+
+    kalman: {
+
+        sigmaQ = 0.001;
+        
+    };
+   
+    # Parameters used by the particle filter only
+
+    particle: {
+
+        nParticles = 1000;
+        st_alpha = 2.0;
+        st_beta = 0.04;
+        st_ratio = 0.5;
+        ve_alpha = 0.05;
+        ve_beta = 0.2;
+        ve_ratio = 0.3;
+        ac_alpha = 0.5;
+        ac_beta = 0.2;
+        ac_ratio = 0.2;
+        Nmin = 0.7;
+
+    };
+
+    target: ();
+
+    # Output to export tracked sources
+    tracked: {
+
+        format = "undefined";
+        interface: {
+            type = "blackhole";
+        }
+
+        # format = "json";
+        # interface: {
+        #     # type = "terminal";
+        #     type = "socket"; ip = "172.25.112.1"; port = 9000;
+        # };
+
+    };
+
+}
+
+sss:
+{
+    
+    # Mode is either "dds", "dgss" or "dmvdr"
+
+    mode_sep = "dds";
+    mode_pf = "ms";
+
+    gain_sep = 1.0;
+    gain_pf = 10.0;
+
+    dds: {
+
+    };
+
+    dgss: {
+
+        mu = 0.01;
+        lambda = 0.5;
+
+    };
+
+    dmvdr: {
+
+    };
+
+    ms: {
+
+        alphaPmin = 0.07;
+        eta = 0.5;
+        alphaZ = 0.8;        
+        thetaWin = 0.3;
+        alphaWin = 0.3;
+        maxAbsenceProb = 0.9;
+        Gmin = 0.01;
+        winSizeLocal = 3;
+        winSizeGlobal = 23;
+        winSizeFrame = 256;
+
+    };
+
+    ss: {
+
+        Gmin = 0.01;
+        Gmid = 0.9;
+        Gslope = 10.0;
+
+    }
+
+    separated: {
+
+        fS = 44100;
+        hopSize = 512;
+        nBits = 16;        
+
+        interface: {
+            type = "file";
+            path = "separated.raw";
+        }        
+
+    };
+
+    postfiltered: {
+
+        fS = 44100;
+        hopSize = 512;
+        nBits = 16;        
+
+        interface: {
+            type = "file";
+            path = "postfiltered.raw";
+        }        
+
+    };
+
+}
+
+classify:
+{
+    
+    frameSize = 1024;
+    winSize = 3;
+    tauMin = 32;
+    tauMax = 200;
+    deltaTauMax = 7;
+    alpha = 0.3;
+    gamma = 0.05;
+    phiMin = 0.15;
+    r0 = 0.2;    
+
+    category: {
+
+        format = "undefined";
+
+        interface: {
+            type = "blackhole";
+        }
+
+    }
+
+}

--- a/src/source/src_hops.c
+++ b/src/source/src_hops.c
@@ -1,510 +1,585 @@
-   
-   /**
-    * \file     src_hops.c
-    * \author   François Grondin <francois.grondin2@usherbrooke.ca>
-    * \version  2.0
-    * \date     2018-03-18
-    * \copyright
-    *
-    * This program is free software: you can redistribute it and/or modify
-    * it under the terms of the GNU General Public License as published by
-    * the Free Software Foundation, either version 3 of the License, or
-    * (at your option) any later version.
-    *
-    * This program is distributed in the hope that it will be useful,
-    * but WITHOUT ANY WARRANTY; without even the implied warranty of
-    * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    * GNU General Public License for more details.
-    * 
-    * You should have received a copy of the GNU General Public License
-    * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-    *
-    */
-    
-    #include <source/src_hops.h>
 
-    src_hops_obj * src_hops_construct(const src_hops_cfg * src_hops_config, const msg_hops_cfg * msg_hops_config) {
+/**
+ * \file     src_hops.c
+ * \author   François Grondin <francois.grondin2@usherbrooke.ca>
+ * \version  2.0
+ * \date     2018-03-18
+ * \copyright
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
-        src_hops_obj * obj;
-        unsigned int nBytes;
+#include <source/src_hops.h>
 
-        obj = (src_hops_obj *) malloc(sizeof(src_hops_obj));
+src_hops_obj *src_hops_construct(const src_hops_cfg *src_hops_config, const msg_hops_cfg *msg_hops_config)
+{
 
-        obj->timeStamp = 0;
+    src_hops_obj *obj;
+    unsigned int nBytes;
 
-        obj->hopSize = msg_hops_config->hopSize;
-        obj->nChannels = msg_hops_config->nChannels;
-        obj->fS = msg_hops_config->fS;
-        
-        obj->format = format_clone(src_hops_config->format);
-        obj->interface = interface_clone(src_hops_config->interface);
+    obj = (src_hops_obj *)malloc(sizeof(src_hops_obj));
 
-        memset(obj->bytes, 0x00, 4 * sizeof(char));
+    obj->timeStamp = 0;
 
-        if (!(((obj->interface->type == interface_file)  && (obj->format->type == format_binary_int08)) ||
-              ((obj->interface->type == interface_file)  && (obj->format->type == format_binary_int16)) ||
-              ((obj->interface->type == interface_file)  && (obj->format->type == format_binary_int24)) ||
-              ((obj->interface->type == interface_file)  && (obj->format->type == format_binary_int32)) ||
-              ((obj->interface->type == interface_soundcard)  && (obj->format->type == format_binary_int08)) ||
-              ((obj->interface->type == interface_soundcard)  && (obj->format->type == format_binary_int16)) ||
-              ((obj->interface->type == interface_soundcard)  && (obj->format->type == format_binary_int24)) ||
-              ((obj->interface->type == interface_soundcard)  && (obj->format->type == format_binary_int32)))) {
-            
-            printf("Source hops: Invalid interface and/or format.\n");
-            exit(EXIT_FAILURE);
+    obj->hopSize = msg_hops_config->hopSize;
+    obj->nChannels = msg_hops_config->nChannels;
+    obj->fS = msg_hops_config->fS;
 
-        }
+    obj->format = format_clone(src_hops_config->format);
+    obj->interface = interface_clone(src_hops_config->interface);
 
-        obj->buffer = (char *) malloc(sizeof(char) * obj->hopSize * obj->nChannels * 4);
-        memset(obj->buffer, 0x00, sizeof(char) * obj->hopSize * obj->nChannels * 4);
+    memset(obj->bytes, 0x00, 4 * sizeof(char));
 
-        switch (obj->format->type) {
+    if (!((obj->interface->type == interface_file ||
+           obj->interface->type == interface_soundcard ||
+           obj->interface->type == interface_socket) &&
+          (obj->format->type == format_binary_int08 ||
+           obj->format->type == format_binary_int16 ||
+           obj->format->type == format_binary_int24 ||
+           obj->format->type == format_binary_int32)))
+    {
 
-            case format_binary_int08: obj->bufferSize = obj->hopSize * obj->nChannels * 1; break;
-            case format_binary_int16: obj->bufferSize = obj->hopSize * obj->nChannels * 2; break;
-            case format_binary_int24: obj->bufferSize = obj->hopSize * obj->nChannels * 3; break;
-            case format_binary_int32: obj->bufferSize = obj->hopSize * obj->nChannels * 4; break;
-
-        }      
-
-        obj->out = (msg_hops_obj *) NULL;
-        
-        return obj;
-
+        printf("Source hops: Invalid interface and/or format.\n");
+        exit(EXIT_FAILURE);
     }
 
-    void src_hops_destroy(src_hops_obj * obj) {
+    obj->buffer = (char *)malloc(sizeof(char) * obj->hopSize * obj->nChannels * 4);
+    memset(obj->buffer, 0x00, sizeof(char) * obj->hopSize * obj->nChannels * 4);
 
-        free((void *) obj->buffer);
-        format_destroy(obj->format);
-        interface_destroy(obj->interface);
+    switch (obj->format->type)
+    {
 
-        free((void *) obj);
-
+    case format_binary_int08:
+        obj->bufferSize = obj->hopSize * obj->nChannels * 1;
+        break;
+    case format_binary_int16:
+        obj->bufferSize = obj->hopSize * obj->nChannels * 2;
+        break;
+    case format_binary_int24:
+        obj->bufferSize = obj->hopSize * obj->nChannels * 3;
+        break;
+    case format_binary_int32:
+        obj->bufferSize = obj->hopSize * obj->nChannels * 4;
+        break;
     }
 
-    void src_hops_connect(src_hops_obj * obj, msg_hops_obj * out) {
+    obj->out = (msg_hops_obj *)NULL;
 
-        obj->out = out;
+    return obj;
+}
 
+void src_hops_destroy(src_hops_obj *obj)
+{
+
+    free((void *)obj->buffer);
+    format_destroy(obj->format);
+    interface_destroy(obj->interface);
+
+    free((void *)obj);
+}
+
+void src_hops_connect(src_hops_obj *obj, msg_hops_obj *out)
+{
+
+    obj->out = out;
+}
+
+void src_hops_disconnect(src_hops_obj *obj)
+{
+
+    obj->out = (msg_hops_obj *)NULL;
+}
+
+void src_hops_open(src_hops_obj *obj)
+{
+
+    switch (obj->interface->type)
+    {
+
+    case interface_file:
+
+        src_hops_open_interface_file(obj);
+
+        break;
+
+    case interface_soundcard:
+
+        src_hops_open_interface_soundcard(obj);
+
+        break;
+
+    case interface_socket:
+
+        src_hops_open_interface_socket(obj);
+
+        break;
+
+    default:
+
+        printf("Source hops: Invalid interface type.\n");
+        exit(EXIT_FAILURE);
+
+        break;
+    }
+}
+
+void src_hops_open_interface_file(src_hops_obj *obj)
+{
+
+    obj->fp = fopen(obj->interface->fileName, "rb");
+
+    if (obj->fp == NULL)
+    {
+        printf("Cannot open file %s\n", obj->interface->fileName);
+        exit(EXIT_FAILURE);
+    }
+}
+
+void src_hops_open_interface_soundcard(src_hops_obj *obj)
+{
+
+    snd_pcm_hw_params_t *hw_params;
+    snd_pcm_format_t format;
+    int err;
+
+    switch (obj->format->type)
+    {
+
+    case format_binary_int08:
+
+        format = SND_PCM_FORMAT_S8;
+
+        break;
+
+    case format_binary_int16:
+
+        format = SND_PCM_FORMAT_S16_LE;
+
+        break;
+
+    case format_binary_int24:
+
+        format = SND_PCM_FORMAT_S24_LE;
+
+        break;
+
+    case format_binary_int32:
+
+        format = SND_PCM_FORMAT_S32_LE;
+
+        break;
+
+    default:
+
+        printf("Source hops: Invalid format.\n");
+        exit(EXIT_FAILURE);
+
+        break;
     }
 
-    void src_hops_disconnect(src_hops_obj * obj) {
-
-        obj->out = (msg_hops_obj *) NULL;
-
+    if ((err = snd_pcm_open(&(obj->ch), obj->interface->deviceName, SND_PCM_STREAM_CAPTURE, 0)) < 0)
+    {
+        printf("Source hops: Cannot open audio device %s: %s\n", obj->interface->deviceName, snd_strerror(err));
+        exit(EXIT_FAILURE);
     }
 
-    void src_hops_open(src_hops_obj * obj) {
-
-        switch(obj->interface->type) {
-
-            case interface_file:
-
-                src_hops_open_interface_file(obj);
-
-            break;
-
-            case interface_soundcard:
-
-                src_hops_open_interface_soundcard(obj);
-
-            break;
-
-            default:
-
-                printf("Source hops: Invalid interface type.\n");
-                exit(EXIT_FAILURE);
-
-            break;
-
-        }        
-
+    if ((err = snd_pcm_hw_params_malloc(&hw_params)) < 0)
+    {
+        printf("Source hops: Cannot allocate hardware parameter structure: %s\n", snd_strerror(err));
+        exit(EXIT_FAILURE);
     }
 
-    void src_hops_open_interface_file(src_hops_obj * obj) {
-
-        obj->fp = fopen(obj->interface->fileName, "rb");
-
-        if (obj->fp == NULL) {
-            printf("Cannot open file %s\n",obj->interface->fileName);
-            exit(EXIT_FAILURE);
-        }
-
+    if ((err = snd_pcm_hw_params_any(obj->ch, hw_params)) < 0)
+    {
+        printf("Source hops: Cannot initialize hardware parameter structure: %s\n", snd_strerror(err));
+        exit(EXIT_FAILURE);
     }
 
-    void src_hops_open_interface_soundcard(src_hops_obj * obj) {
-
-        snd_pcm_hw_params_t * hw_params;
-        snd_pcm_format_t format;
-        int err;
-
-        switch (obj->format->type) {
-            
-            case format_binary_int08:
-
-                format = SND_PCM_FORMAT_S8;
-
-            break;
-
-            case format_binary_int16:
-
-                format = SND_PCM_FORMAT_S16_LE;
-
-            break;
-
-            case format_binary_int24:
-
-                format = SND_PCM_FORMAT_S24_LE;
-
-            break;
-            
-            case format_binary_int32:
-            
-                format = SND_PCM_FORMAT_S32_LE;
-            
-            break;
-
-            default:
-
-                printf("Source hops: Invalid format.\n");
-                exit(EXIT_FAILURE);
-
-            break;
-
-        }       
-
-
-        if ((err = snd_pcm_open(&(obj->ch), obj->interface->deviceName, SND_PCM_STREAM_CAPTURE, 0)) < 0) {
-            printf("Source hops: Cannot open audio device %s: %s\n",obj->interface->deviceName, snd_strerror(err));
-            exit(EXIT_FAILURE);
-        }
-
-        if ((err = snd_pcm_hw_params_malloc(&hw_params)) < 0) {
-            printf("Source hops: Cannot allocate hardware parameter structure: %s\n", snd_strerror(err));
-            exit(EXIT_FAILURE);
-        }
-
-        if ((err = snd_pcm_hw_params_any(obj->ch, hw_params)) < 0) {
-            printf("Source hops: Cannot initialize hardware parameter structure: %s\n", snd_strerror(err));
-            exit(EXIT_FAILURE);
-        }
-
-        if ((err = snd_pcm_hw_params_set_access(obj->ch, hw_params, SND_PCM_ACCESS_RW_INTERLEAVED)) < 0) {
-            printf("Source hops: Cannot set access type: %s\n", snd_strerror(err));
-            exit(EXIT_FAILURE);
-        }
-
-        if ((err = snd_pcm_hw_params_set_format(obj->ch, hw_params, format)) < 0) {
-            printf("Source hops: Cannot set sample format: %s\n", snd_strerror(err));
-            exit(EXIT_FAILURE);
-        }
-
-        if ((err = snd_pcm_hw_params_set_rate(obj->ch, hw_params, obj->fS, 0)) < 0) {
-            printf("Source hops: Cannot set sample rate: %s\n", snd_strerror(err));
-            exit(EXIT_FAILURE);
-        }
-
-        if ((err = snd_pcm_hw_params_set_channels(obj->ch, hw_params, obj->nChannels)) < 0) {
-            printf("Source hops: Cannot set channel count: %s\n", snd_strerror(err));
-            exit(EXIT_FAILURE);
-        }
-
-        if ((err = snd_pcm_hw_params(obj->ch, hw_params)) < 0) {
-            printf("Source hops: Cannot set parameters: %s\n", snd_strerror(err));
-            exit(EXIT_FAILURE);
-        }
-
-        snd_pcm_hw_params_free(hw_params);
-
-        if ((err = snd_pcm_prepare(obj->ch)) < 0) {
-            printf("Source hops: Cannot prepare audio interface for use: %s\n", snd_strerror(err));
-            exit(EXIT_FAILURE);
-        }
-
+    if ((err = snd_pcm_hw_params_set_access(obj->ch, hw_params, SND_PCM_ACCESS_RW_INTERLEAVED)) < 0)
+    {
+        printf("Source hops: Cannot set access type: %s\n", snd_strerror(err));
+        exit(EXIT_FAILURE);
     }
 
-    void src_hops_close(src_hops_obj * obj) {
-
-        switch(obj->interface->type) {
-
-            case interface_file:
-
-                src_hops_close_interface_file(obj);
-
-            break;
-
-            case interface_soundcard:
-
-                src_hops_close_interface_soundcard(obj);
-
-            break;
-
-            default:
-
-                printf("Source hops: Invalid interface type.\n");
-                exit(EXIT_FAILURE);
-
-            break;
-
-        }
-
+    if ((err = snd_pcm_hw_params_set_format(obj->ch, hw_params, format)) < 0)
+    {
+        printf("Source hops: Cannot set sample format: %s\n", snd_strerror(err));
+        exit(EXIT_FAILURE);
     }
 
-    void src_hops_close_interface_file(src_hops_obj * obj) {
-
-        fclose(obj->fp);
-
+    if ((err = snd_pcm_hw_params_set_rate(obj->ch, hw_params, obj->fS, 0)) < 0)
+    {
+        printf("Source hops: Cannot set sample rate: %s\n", snd_strerror(err));
+        exit(EXIT_FAILURE);
     }
 
-    void src_hops_close_interface_soundcard(src_hops_obj * obj) {
-
-        snd_pcm_close(obj->ch);
-
+    if ((err = snd_pcm_hw_params_set_channels(obj->ch, hw_params, obj->nChannels)) < 0)
+    {
+        printf("Source hops: Cannot set channel count: %s\n", snd_strerror(err));
+        exit(EXIT_FAILURE);
     }
 
-    int src_hops_process(src_hops_obj * obj) {
-
-        int rtnValue;
-
-        switch(obj->format->type) {
-
-            case format_binary_int08:
-
-                src_hops_process_format_binary_int08(obj);
-
-            break;
-
-            case format_binary_int16:
-
-                src_hops_process_format_binary_int16(obj);                
-
-            break;
-
-            case format_binary_int24:
-
-                src_hops_process_format_binary_int24(obj);
-
-            break;
-
-            case format_binary_int32:
-
-                src_hops_process_format_binary_int32(obj);
-
-            break;
-
-            default:
-
-                printf("Source hops: Invalid format type.\n");
-                exit(EXIT_FAILURE);
-
-            break;
-
-        }
-
-        switch(obj->interface->type) {
-
-            case interface_file:
-
-                rtnValue = src_hops_process_interface_file(obj);
-
-            break;
-
-            case interface_soundcard:
-
-                rtnValue = src_hops_process_interface_soundcard(obj);
-
-            break;
-
-            default:
-
-                printf("Source hops: Invalid interface type.\n");
-                exit(EXIT_FAILURE);
-
-            break;           
-
-        }
-
-        obj->timeStamp++;
-        obj->out->timeStamp = obj->timeStamp;
-
-        return rtnValue;
-
+    if ((err = snd_pcm_hw_params(obj->ch, hw_params)) < 0)
+    {
+        printf("Source hops: Cannot set parameters: %s\n", snd_strerror(err));
+        exit(EXIT_FAILURE);
     }
 
-    int src_hops_process_interface_file(src_hops_obj * obj) {
+    snd_pcm_hw_params_free(hw_params);
 
-        unsigned int nBytesTotal;
-        int rtnValue;
+    if ((err = snd_pcm_prepare(obj->ch)) < 0)
+    {
+        printf("Source hops: Cannot prepare audio interface for use: %s\n", snd_strerror(err));
+        exit(EXIT_FAILURE);
+    }
+}
 
-        nBytesTotal = fread(obj->buffer, sizeof(char), obj->bufferSize, obj->fp);
+void src_hops_open_interface_socket(src_hops_obj *obj)
+{
 
-        if (nBytesTotal == obj->bufferSize) {
-            
-            rtnValue = 0;    
+    memset(&(obj->sserver), 0x00, sizeof(struct sockaddr_in));
 
-        }
-        else {
+    obj->sserver.sin_family = AF_INET;
+    obj->sserver.sin_addr.s_addr = inet_addr(obj->interface->ip);
+    obj->sserver.sin_port = htons(obj->interface->port);
+    obj->sid = socket(AF_INET, SOCK_STREAM, 0);
 
-            rtnValue = -1;
+    if ((connect(obj->sid, (struct sockaddr *)&(obj->sserver), sizeof(obj->sserver))) < 0)
+    {
 
-        }
+        printf("Source hops: Cannot connect to server\n");
+        exit(EXIT_FAILURE);
+    }
+}
 
-        return rtnValue;
+void src_hops_close(src_hops_obj *obj)
+{
 
+    switch (obj->interface->type)
+    {
+
+    case interface_file:
+
+        src_hops_close_interface_file(obj);
+
+        break;
+
+    case interface_soundcard:
+
+        src_hops_close_interface_soundcard(obj);
+
+        break;
+
+    default:
+
+        printf("Source hops: Invalid interface type.\n");
+        exit(EXIT_FAILURE);
+
+        break;
+    }
+}
+
+void src_hops_close_interface_file(src_hops_obj *obj)
+{
+
+    fclose(obj->fp);
+}
+
+void src_hops_close_interface_soundcard(src_hops_obj *obj)
+{
+
+    snd_pcm_close(obj->ch);
+}
+
+void src_hops_close_interface_socket(src_hops_obj *obj)
+{
+    close(obj->sid);
+}
+
+int src_hops_process(src_hops_obj *obj)
+{
+
+    int rtnValue;
+
+    switch (obj->format->type)
+    {
+
+    case format_binary_int08:
+
+        src_hops_process_format_binary_int08(obj);
+
+        break;
+
+    case format_binary_int16:
+
+        src_hops_process_format_binary_int16(obj);
+
+        break;
+
+    case format_binary_int24:
+
+        src_hops_process_format_binary_int24(obj);
+
+        break;
+
+    case format_binary_int32:
+
+        src_hops_process_format_binary_int32(obj);
+
+        break;
+
+    default:
+
+        printf("Source hops: Invalid format type.\n");
+        exit(EXIT_FAILURE);
+
+        break;
     }
 
-    int src_hops_process_interface_soundcard(src_hops_obj * obj) {
+    switch (obj->interface->type)
+    {
 
-        unsigned int nSamples;
-        int rtnValue;
-        int err;
+    case interface_file:
 
-        if (err = snd_pcm_readi(obj->ch, obj->buffer, obj->hopSize) > 0) {
-            
-            rtnValue = 0;    
+        rtnValue = src_hops_process_interface_file(obj);
 
-        }
-        else {
+        break;
 
-            rtnValue = -1;
+    case interface_soundcard:
 
-        }
+        rtnValue = src_hops_process_interface_soundcard(obj);
 
-        return rtnValue;
+        break;
 
+    case interface_socket:
+
+        rtnValue = src_hops_process_interface_socket(obj);
+
+        break;
+
+    default:
+
+        printf("Source hops: Invalid interface type.\n");
+        exit(EXIT_FAILURE);
+
+        break;
     }
 
-    void src_hops_process_format_binary_int08(src_hops_obj * obj) {
+    obj->timeStamp++;
+    obj->out->timeStamp = obj->timeStamp;
 
-        unsigned int iSample;
-        unsigned int iChannel;
-        unsigned int nBytes;
-        float sample;
+    return rtnValue;
+}
 
-        nBytes = 1;
+int src_hops_process_interface_file(src_hops_obj *obj)
+{
 
-        for (iSample = 0; iSample < obj->hopSize; iSample++) {
+    unsigned int nBytesTotal;
+    int rtnValue;
 
-            for (iChannel = 0; iChannel < obj->nChannels; iChannel++) {
+    nBytesTotal = fread(obj->buffer, sizeof(char), obj->bufferSize, obj->fp);
 
-                memcpy(&(obj->bytes[4-nBytes]),
-                       &(obj->buffer[(iSample * obj->nChannels + iChannel) * nBytes]),
-                       sizeof(char) * nBytes);
+    if (nBytesTotal == obj->bufferSize)
+    {
 
-                sample = pcm_signedXXbits2normalized(obj->bytes, nBytes);
+        rtnValue = 0;
+    }
+    else
+    {
 
-                obj->out->hops->array[iChannel][iSample] = sample;
-
-            }
-
-        }
-
+        rtnValue = -1;
     }
 
-    void src_hops_process_format_binary_int16(src_hops_obj * obj) {
+    return rtnValue;
+}
 
-        unsigned int iSample;
-        unsigned int iChannel;
-        unsigned int nBytes;
-        float sample;
+int src_hops_process_interface_soundcard(src_hops_obj *obj)
+{
 
-        nBytes = 2;
+    unsigned int nSamples;
+    int rtnValue;
+    int err;
 
-        for (iSample = 0; iSample < obj->hopSize; iSample++) {
+    if (err = snd_pcm_readi(obj->ch, obj->buffer, obj->hopSize) > 0)
+    {
 
-            for (iChannel = 0; iChannel < obj->nChannels; iChannel++) {
+        rtnValue = 0;
+    }
+    else
+    {
 
-                memcpy(&(obj->bytes[4-nBytes]),
-                       &(obj->buffer[(iSample * obj->nChannels + iChannel) * nBytes]),
-                       sizeof(char) * nBytes);
-
-                sample = pcm_signedXXbits2normalized(obj->bytes, nBytes);
-
-                obj->out->hops->array[iChannel][iSample] = sample;
-
-            }
-
-        }
-
+        rtnValue = -1;
     }
 
-    void src_hops_process_format_binary_int24(src_hops_obj * obj) {
+    return rtnValue;
+}
 
-        unsigned int iSample;
-        unsigned int iChannel;
-        unsigned int nBytes;
-        float sample;
+int src_hops_process_interface_socket(src_hops_obj *obj)
+{
+    unsigned int nBytesTotal;
+    int rtnValue;
 
-        nBytes = 3;
+    // ssize_t recv(int sockfd, void *buf, size_t len, int flags);
+    nBytesTotal = recv(obj->sid, obj->buffer, obj->bufferSize, 0);
 
-        for (iSample = 0; iSample < obj->hopSize; iSample++) {
+    if (nBytesTotal == obj->bufferSize)
+    {
+        printf("Received %d bytes", nBytesTotal);
+        rtnValue = 0;
+    }
+    else
+    {
 
-            for (iChannel = 0; iChannel < obj->nChannels; iChannel++) {
-
-                memcpy(&(obj->bytes[4-nBytes]),
-                       &(obj->buffer[(iSample * obj->nChannels + iChannel) * nBytes]),
-                       sizeof(char) * nBytes);
-
-                sample = pcm_signedXXbits2normalized(obj->bytes, nBytes);
-
-                obj->out->hops->array[iChannel][iSample] = sample;
-
-            }
-
-        }
-
+        rtnValue = -1;
     }
 
-    void src_hops_process_format_binary_int32(src_hops_obj * obj) {
+    return rtnValue;
+}
 
-        unsigned int iSample;
-        unsigned int iChannel;
-        unsigned int nBytes;
-        float sample;
+void src_hops_process_format_binary_int08(src_hops_obj *obj)
+{
 
-        nBytes = 4;
+    unsigned int iSample;
+    unsigned int iChannel;
+    unsigned int nBytes;
+    float sample;
 
-        for (iSample = 0; iSample < obj->hopSize; iSample++) {
+    nBytes = 1;
 
-            for (iChannel = 0; iChannel < obj->nChannels; iChannel++) {
+    for (iSample = 0; iSample < obj->hopSize; iSample++)
+    {
 
-                memcpy(&(obj->bytes[4-nBytes]),
-                       &(obj->buffer[(iSample * obj->nChannels + iChannel) * nBytes]),
-                       sizeof(char) * nBytes);
+        for (iChannel = 0; iChannel < obj->nChannels; iChannel++)
+        {
 
-                sample = pcm_signedXXbits2normalized(obj->bytes, nBytes);
+            memcpy(&(obj->bytes[4 - nBytes]),
+                   &(obj->buffer[(iSample * obj->nChannels + iChannel) * nBytes]),
+                   sizeof(char) * nBytes);
 
-                obj->out->hops->array[iChannel][iSample] = sample;
+            sample = pcm_signedXXbits2normalized(obj->bytes, nBytes);
 
-            }
-
+            obj->out->hops->array[iChannel][iSample] = sample;
         }
+    }
+}
 
+void src_hops_process_format_binary_int16(src_hops_obj *obj)
+{
+
+    unsigned int iSample;
+    unsigned int iChannel;
+    unsigned int nBytes;
+    float sample;
+
+    nBytes = 2;
+
+    for (iSample = 0; iSample < obj->hopSize; iSample++)
+    {
+
+        for (iChannel = 0; iChannel < obj->nChannels; iChannel++)
+        {
+
+            memcpy(&(obj->bytes[4 - nBytes]),
+                   &(obj->buffer[(iSample * obj->nChannels + iChannel) * nBytes]),
+                   sizeof(char) * nBytes);
+
+            sample = pcm_signedXXbits2normalized(obj->bytes, nBytes);
+
+            obj->out->hops->array[iChannel][iSample] = sample;
+        }
+    }
+}
+
+void src_hops_process_format_binary_int24(src_hops_obj *obj)
+{
+
+    unsigned int iSample;
+    unsigned int iChannel;
+    unsigned int nBytes;
+    float sample;
+
+    nBytes = 3;
+
+    for (iSample = 0; iSample < obj->hopSize; iSample++)
+    {
+
+        for (iChannel = 0; iChannel < obj->nChannels; iChannel++)
+        {
+
+            memcpy(&(obj->bytes[4 - nBytes]),
+                   &(obj->buffer[(iSample * obj->nChannels + iChannel) * nBytes]),
+                   sizeof(char) * nBytes);
+
+            sample = pcm_signedXXbits2normalized(obj->bytes, nBytes);
+
+            obj->out->hops->array[iChannel][iSample] = sample;
+        }
+    }
+}
+
+void src_hops_process_format_binary_int32(src_hops_obj *obj)
+{
+
+    unsigned int iSample;
+    unsigned int iChannel;
+    unsigned int nBytes;
+    float sample;
+
+    nBytes = 4;
+
+    for (iSample = 0; iSample < obj->hopSize; iSample++)
+    {
+
+        for (iChannel = 0; iChannel < obj->nChannels; iChannel++)
+        {
+
+            memcpy(&(obj->bytes[4 - nBytes]),
+                   &(obj->buffer[(iSample * obj->nChannels + iChannel) * nBytes]),
+                   sizeof(char) * nBytes);
+
+            sample = pcm_signedXXbits2normalized(obj->bytes, nBytes);
+
+            obj->out->hops->array[iChannel][iSample] = sample;
+        }
+    }
+}
+
+src_hops_cfg *src_hops_cfg_construct(void)
+{
+
+    src_hops_cfg *cfg;
+
+    cfg = (src_hops_cfg *)malloc(sizeof(src_hops_cfg));
+
+    cfg->format = (format_obj *)NULL;
+    cfg->interface = (interface_obj *)NULL;
+
+    return cfg;
+}
+
+void src_hops_cfg_destroy(src_hops_cfg *src_hops_config)
+{
+
+    if (src_hops_config->format != NULL)
+    {
+        format_destroy(src_hops_config->format);
+    }
+    if (src_hops_config->interface != NULL)
+    {
+        interface_destroy(src_hops_config->interface);
     }
 
-    src_hops_cfg * src_hops_cfg_construct(void) {
-
-        src_hops_cfg * cfg;
-
-        cfg = (src_hops_cfg *) malloc(sizeof(src_hops_cfg));
-
-        cfg->format = (format_obj *) NULL;
-        cfg->interface = (interface_obj *) NULL;
-
-        return cfg;
-
-    }
-
-    void src_hops_cfg_destroy(src_hops_cfg * src_hops_config) {
-
-        if (src_hops_config->format != NULL) {
-            format_destroy(src_hops_config->format);
-        }
-        if (src_hops_config->interface != NULL) {
-            interface_destroy(src_hops_config->interface);
-        }
-
-        free((void *) src_hops_config);
-
-    }
+    free((void *)src_hops_config);
+}

--- a/src/source/src_hops.c
+++ b/src/source/src_hops.c
@@ -282,6 +282,12 @@ void src_hops_close(src_hops_obj *obj)
 
         break;
 
+    case interface_socket:
+
+        src_hops_close_interface_socket(obj);
+
+        break;
+
     default:
 
         printf("Source hops: Invalid interface type.\n");
@@ -432,11 +438,11 @@ int src_hops_process_interface_socket(src_hops_obj *obj)
     int rtnValue;
 
     // ssize_t recv(int sockfd, void *buf, size_t len, int flags);
-    nBytesTotal = recv(obj->sid, obj->buffer, obj->bufferSize, 0);
+    nBytesTotal = recv(obj->sid, obj->buffer, obj->bufferSize, MSG_WAITALL);
 
     if (nBytesTotal == obj->bufferSize)
     {
-        printf("Received %d bytes", nBytesTotal);
+
         rtnValue = 0;
     }
     else


### PR DESCRIPTION
This pull request makes it possible to specify `interface = "socket"` in the configuration for raw inputs. This is useful when you want to offload sound processing from a microcontroller to a more powerful computer.