### PR TITLE
Install executables and public headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,11 @@
 project(ODAS)
-cmake_minimum_required(VERSION 2.4.6)
+cmake_minimum_required(VERSION 2.4.6..3.16)
 
 if(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)
 endif(COMMAND cmake_policy)
+
+option(ODAS_INSTALL_EXECUTABLES "Install the odaslive and odasserver executables along with the odas library" OFF)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PC_FFTW3 REQUIRED fftw3f)
@@ -17,6 +19,9 @@ include_directories("${PROJECT_SOURCE_DIR}/include")
 if(NOT CMAKE_BUILD_TYPE)
   SET(CMAKE_BUILD_TYPE "Release")
 endif(NOT CMAKE_BUILD_TYPE)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
 
 #Add base directory for includes (global)
 include_directories(include/odas)
@@ -186,8 +191,89 @@ set(SRC
 
 )
 
+set(PUBLIC_HEADER
+
+    include/odas.h
+
+    include/connector/con_categories.h
+    include/connector/con_hops.h
+    include/connector/con_pots.h
+    include/connector/con_powers.h
+    include/connector/con_spectra.h
+    include/connector/con_targets.h
+    include/connector/con_tracks.h
+
+    include/injector/inj_targets.h
+
+    include/message/msg_categories.h
+    include/message/msg_hops.h
+    include/message/msg_pots.h
+    include/message/msg_powers.h
+    include/message/msg_spectra.h
+    include/message/msg_targets.h
+    include/message/msg_tracks.h
+
+    include/module/mod_classify.h
+    include/module/mod_istft.h
+    include/module/mod_mapping.h
+    include/module/mod_noise.h
+    include/module/mod_resample.h
+    include/module/mod_ssl.h
+    include/module/mod_sst.h
+    include/module/mod_sss.h
+    include/module/mod_stft.h
+    include/module/mod_volume.h
+
+    include/sink/snk_categories.h
+    include/sink/snk_hops.h
+    include/sink/snk_pots.h
+    include/sink/snk_powers.h
+    include/sink/snk_spectra.h
+    include/sink/snk_tracks.h
+
+    include/source/src_hops.h
+
+    include/acconector/acon_categories.h
+    include/acconector/acon_hops.h
+    include/acconector/acon_pots.h
+    include/acconector/acon_powers.h
+    include/acconector/acon_spectra.h
+    include/acconector/acon_targets.h
+    include/acconector/acon_tracks.h
+
+    include/ammessage/amsg_categories.h
+    include/ammessage/amsg_hops.h
+    include/ammessage/amsg_pots.h
+    include/ammessage/amsg_powers.h
+    include/ammessage/amsg_spectra.h
+    include/ammessage/amsg_targets.h
+    include/ammessage/amsg_tracks.h
+
+    include/amodule/amod_classify.h
+    include/amodule/amod_istft.h
+    include/amodule/amod_mapping.h
+    include/amodule/amod_noise.h
+    include/amodule/amod_resample.h
+    include/amodule/amod_ssl.h
+    include/amodule/amod_sst.h
+    include/amodule/amod_sss.h
+    include/amodule/amod_stft.h
+    include/amodule/amod_volume.h
+
+    include/asink/asnk_categories.h
+    include/asink/asnk_hops.h
+    include/asink/asnk_pots.h
+    include/asink/asnk_powers.h
+    include/asink/asnk_spectra.h
+    include/asink/asnk_tracks.h
+
+    include/asource/asrc_hops.h
+
+)
+
 add_library(odas SHARED
 	${SRC}
+    PUBLIC_HEADER ${PUBLIC_HEADER}
 )
 
 target_link_libraries(odas
@@ -218,4 +304,12 @@ target_link_libraries(odasserver
     odas
 )
 
-install(TARGETS odas DESTINATION lib)
+install(TARGETS odas LIBRARY DESTINATION lib PUBLIC_HEADER DESTINATION include)
+
+if(ODAS_INSTALL_EXECUTABLES)
+    install(TARGETS odaslive DESTINATION bin)
+    install(TARGETS odasserver DESTINATION bin)
+endif()
+
+unset(CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY)


### PR DESCRIPTION
Add a CMake option to install exacutables `odaslive` and `odasserver`.
Add public headers to library instally.
Bring back `bin` and `lib` folders, but move them to PROJECT_BINARY_DIR instead of PROJECT_SOURCE_DIR.
Closes #259 