### PR TITLE
Add a CMake option to fix odas_ros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ if(COMMAND cmake_policy)
 endif(COMMAND cmake_policy)
 
 option(ODAS_INSTALL_EXECUTABLES "Install the odaslive and odasserver executables along with the odas library" OFF)
+option(ODAS_FORCE_BIN_AND_LIB_DIRS "Force the installation of the odas library and executables in the bin and lib directories" ON)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PC_FFTW3 REQUIRED fftw3f)
@@ -20,13 +21,13 @@ if(NOT CMAKE_BUILD_TYPE)
     SET(CMAKE_BUILD_TYPE "Release")
 endif(NOT CMAKE_BUILD_TYPE)
 
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
+if(ODAS_FORCE_BIN_AND_LIB_DIRS)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
+endif()
 
 #Add base directory for includes (global)
 include_directories(include/odas)
-
-add_subdirectory(include)
 
 set(SRC
 
@@ -236,5 +237,7 @@ if(ODAS_INSTALL_EXECUTABLES)
     install(TARGETS odasserver DESTINATION bin)
 endif()
 
-unset(CMAKE_RUNTIME_OUTPUT_DIRECTORY)
-unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+if(ODAS_FORCE_BIN_AND_LIB_DIRS)
+    unset(CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+    unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+endif()

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,8 +1,0 @@
-#Scan for headers and add them for installation
-file(GLOB_RECURSE ODAS_ALL_INCLUDES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.h)
-
-message(STATUS "HEADER FILES: ${ODAS_ALL_INCLUDES}")
-
-add_custom_target(odas_headers SOURCES ${ODAS_ALL_INCLUDES})
-
-install(FILES ${ODAS_ALL_INCLUDES} DESTINATION include)


### PR DESCRIPTION
Add a CMake option to disable the `bin` and `lib` specific directory. causing dynamic link problems when using odas_ros.
Also removed a redundant CMakeLists.txt to install headers, as header installation is now part of the main CMakeLists.txt