### PR TITLE
Use double instead of float variables to limit the drift issues.

### DIFF
--- a/include/odas/module/mod_resample.h
+++ b/include/odas/module/mod_resample.h
@@ -17,7 +17,7 @@
     * but WITHOUT ANY WARRANTY; without even the implied warranty of
     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     * GNU General Public License for more details.
-    * 
+    *
     * You should have received a copy of the GNU General Public License
     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
     *
@@ -53,8 +53,8 @@
         unsigned int fSout;
         unsigned int hopSizeIn;
         unsigned int hopSizeOut;
-        float ratio;
-        
+        double ratio;
+
         unsigned int frameSize;
         unsigned int halfFrameSize;
         unsigned int lowPassCut;
@@ -62,7 +62,7 @@
         hop2hop_buffer_obj * hop2hop;
 
         hop2frame_obj * hop2frame;
-        frames_obj * framesAnalysis; 
+        frames_obj * framesAnalysis;
         frame2freq_obj * frame2freq;
         freqs_obj * freqsAnalysis;
         freq2freq_lowpass_obj * freq2freq_lowpass;
@@ -80,7 +80,7 @@
     } mod_resample_obj;
 
     typedef struct mod_resample_cfg {
-        
+
         unsigned int fSin;
         unsigned int fSout;
 
@@ -98,13 +98,13 @@
 
     int mod_resample_process_push_up(mod_resample_obj * obj);
 
-    int mod_resample_process_push_same(mod_resample_obj * obj);    
+    int mod_resample_process_push_same(mod_resample_obj * obj);
 
     int mod_resample_process_pop_down(mod_resample_obj * obj);
 
     int mod_resample_process_pop_up(mod_resample_obj * obj);
 
-    int mod_resample_process_pop_same(mod_resample_obj * obj);    
+    int mod_resample_process_pop_same(mod_resample_obj * obj);
 
     void mod_resample_connect(mod_resample_obj * obj, msg_hops_obj * in, msg_hops_obj * out);
 

--- a/include/odas/system/hop2hop.h
+++ b/include/odas/system/hop2hop.h
@@ -17,7 +17,7 @@
     * but WITHOUT ANY WARRANTY; without even the implied warranty of
     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     * GNU General Public License for more details.
-    * 
+    *
     * You should have received a copy of the GNU General Public License
     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
     *
@@ -33,7 +33,7 @@
     typedef struct hop2hop_multiplex_obj {
 
         unsigned int hopSize;
-                
+
     } hop2hop_multiplex_obj;
 
     typedef struct hop2hop_buffer_obj {
@@ -41,15 +41,15 @@
         unsigned int nSignals;
         unsigned int hopSizeIn;
         unsigned int hopSizeOut;
-        float intervalIn;
-        float intervalOut;
-        float intervalSize;
+        double intervalIn;
+        double intervalOut;
+        double intervalSize;
         unsigned int bufferSize;
-        float ratio;
-        float delta;
+        double ratio;
+        double delta;
 
-        float iWrite;
-        float iRead;
+        double iWrite;
+        double iRead;
 
         float ** array;
 
@@ -66,9 +66,9 @@
 
     void hop2hop_multiplex_destroy(hop2hop_multiplex_obj * obj);
 
-    void hop2hop_multiplex_process(hop2hop_multiplex_obj * obj, const links_obj * links, const hops_obj * src, hops_obj * dest);    
+    void hop2hop_multiplex_process(hop2hop_multiplex_obj * obj, const links_obj * links, const hops_obj * src, hops_obj * dest);
 
-    hop2hop_buffer_obj * hop2hop_buffer_construct_zero(const unsigned int nSignals, const unsigned int hopSizeIn, const unsigned int hopSizeOut, const float ratio);
+    hop2hop_buffer_obj * hop2hop_buffer_construct_zero(const unsigned int nSignals, const unsigned int hopSizeIn, const unsigned int hopSizeOut, const double ratio);
 
     void hop2hop_buffer_destroy(hop2hop_buffer_obj * obj);
 

--- a/src/module/mod_resample.c
+++ b/src/module/mod_resample.c
@@ -15,12 +15,12 @@
     * but WITHOUT ANY WARRANTY; without even the implied warranty of
     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     * GNU General Public License for more details.
-    * 
+    *
     * You should have received a copy of the GNU General Public License
     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
     *
     */
-    
+
     #include <module/mod_resample.h>
 
     mod_resample_obj * mod_resample_construct(const mod_resample_cfg * mod_resample_config, const msg_hops_cfg * msg_hops_in_config, const msg_hops_cfg * msg_hops_out_config) {
@@ -47,7 +47,7 @@
         obj->fSout = mod_resample_config->fSout;
         obj->hopSizeIn = msg_hops_in_config->hopSize;
         obj->hopSizeOut = msg_hops_out_config->hopSize;
-        obj->ratio = ((float) obj->fSout) / ((float) obj->fSin);
+        obj->ratio = ((double) obj->fSout) / ((double) obj->fSin);
 
         switch (obj->type) {
 
@@ -55,7 +55,7 @@
 
                 obj->frameSize = obj->hopSizeIn * 2;
                 obj->halfFrameSize = obj->frameSize / 2 + 1;
-                obj->lowPassCut = (unsigned int) floorf(((float) (obj->frameSize/2)) * obj->ratio);
+                obj->lowPassCut = (unsigned int) floor(((double) (obj->frameSize/2)) * obj->ratio);
 
                 obj->hop2hop = hop2hop_buffer_construct_zero(obj->nChannels, obj->hopSizeIn, obj->hopSizeOut, obj->ratio);
 
@@ -69,17 +69,17 @@
                 obj->framesSynthesis = frames_construct_zero(obj->nChannels, obj->frameSize);
                 obj->frame2hop = frame2hop_construct_zero(obj->hopSizeIn, obj->frameSize, obj->nChannels);
                 obj->hops = hops_construct_zero(obj->nChannels, obj->hopSizeIn);
-                
+
             break;
 
             case 'u':
 
                 obj->frameSize = obj->hopSizeOut * 2;
                 obj->halfFrameSize = obj->frameSize / 2 + 1;
-                obj->lowPassCut = (unsigned int) floorf(((float) (obj->frameSize/2)) / obj->ratio);
+                obj->lowPassCut = (unsigned int) floor(((double) (obj->frameSize/2)) / obj->ratio);
 
                 obj->hop2hop = hop2hop_buffer_construct_zero(obj->nChannels, obj->hopSizeIn, obj->hopSizeOut, obj->ratio);
-                
+
                 obj->hop2frame = hop2frame_construct_zero(obj->hopSizeOut, obj->frameSize, obj->nChannels);
                 obj->framesAnalysis = frames_construct_zero(obj->nChannels, obj->frameSize);
                 obj->frame2freq = frame2freq_construct_zero(obj->frameSize, obj->halfFrameSize);
@@ -89,7 +89,7 @@
                 obj->freq2frame = freq2frame_construct_zero(obj->frameSize, obj->halfFrameSize);
                 obj->framesSynthesis = frames_construct_zero(obj->nChannels, obj->frameSize);
                 obj->frame2hop = frame2hop_construct_zero(obj->hopSizeOut, obj->frameSize, obj->nChannels);
-                obj->hops = hops_construct_zero(obj->nChannels, obj->hopSizeOut);                
+                obj->hops = hops_construct_zero(obj->nChannels, obj->hopSizeOut);
 
             break;
 
@@ -245,7 +245,7 @@
 
                 if (obj->enabled == 1) {
 
-                    hop2frame_process(obj->hop2frame, 
+                    hop2frame_process(obj->hop2frame,
                                       obj->in->hops,
                                       obj->framesAnalysis);
 
@@ -260,7 +260,7 @@
                     freq2frame_process(obj->freq2frame,
                                        obj->freqsSynthesis,
                                        obj->framesSynthesis);
-                 
+
                     frame2hop_process(obj->frame2hop,
                                       obj->framesSynthesis,
                                       obj->hops);
@@ -321,7 +321,7 @@
             obj->noMorePush = 1;
             rtnValue = -1;
 
-        }        
+        }
 
         return rtnValue;
 
@@ -355,7 +355,7 @@
         else {
 
             obj->noMorePush = 1;
-            rtnValue = -1;            
+            rtnValue = -1;
 
         }
 
@@ -412,7 +412,7 @@
                 hop2hop_buffer_pop(obj->hop2hop,
                                    obj->hops);
 
-                hop2frame_process(obj->hop2frame, 
+                hop2frame_process(obj->hop2frame,
                                   obj->hops,
                                   obj->framesAnalysis);
 
@@ -427,7 +427,7 @@
                 freq2frame_process(obj->freq2frame,
                                    obj->freqsSynthesis,
                                    obj->framesSynthesis);
-             
+
                 frame2hop_process(obj->frame2hop,
                                   obj->framesSynthesis,
                                   obj->out->hops);

--- a/src/system/hop2hop.c
+++ b/src/system/hop2hop.c
@@ -15,12 +15,12 @@
     * but WITHOUT ANY WARRANTY; without even the implied warranty of
     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     * GNU General Public License for more details.
-    * 
+    *
     * You should have received a copy of the GNU General Public License
     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
     *
     */
-    
+
     #include <system/hop2hop.h>
 
     hop2hop_multiplex_obj * hop2hop_multiplex_construct_zero(const unsigned int hopSize) {
@@ -62,7 +62,7 @@
 
     }
 
-    hop2hop_buffer_obj * hop2hop_buffer_construct_zero(const unsigned int nSignals, const unsigned int hopSizeIn, const unsigned int hopSizeOut, const float ratio) {
+    hop2hop_buffer_obj * hop2hop_buffer_construct_zero(const unsigned int nSignals, const unsigned int hopSizeIn, const unsigned int hopSizeOut, const double ratio) {
 
         hop2hop_buffer_obj * obj;
         unsigned int iSignal;
@@ -72,11 +72,11 @@
         obj->nSignals = nSignals;
         obj->hopSizeIn = hopSizeIn;
         obj->hopSizeOut = hopSizeOut;
-        obj->intervalIn = (float) hopSizeIn;
-        obj->intervalOut = ((float) hopSizeOut) / ratio;
-        obj->intervalSize = 0.0f;
+        obj->intervalIn = (double) hopSizeIn;
+        obj->intervalOut = ((double) hopSizeOut) / ratio;
+        obj->intervalSize = 0.0;
         obj->ratio = ratio;
-        obj->delta = 1.0f / ratio;
+        obj->delta = 1.0 / ratio;
 
         if (obj->intervalIn >= obj->intervalOut) {
 
@@ -89,13 +89,13 @@
 
         }
 
-        obj->iRead = 0.0f;
-        obj->iWrite = 0.0f;
+        obj->iRead = 0.0;
+        obj->iWrite = 0.0;
 
         obj->array = (float **) malloc(sizeof(float *) * nSignals);
 
         for (iSignal = 0; iSignal < obj->nSignals; iSignal++) {
-            
+
             obj->array[iSignal] = (float *) malloc(sizeof(float) * obj->bufferSize);
             memset(obj->array[iSignal], 0x00, sizeof(float) * obj->bufferSize);
 
@@ -131,11 +131,11 @@
 
         unsigned int iSignal;
 
-        if ((obj->intervalSize + obj->intervalIn) <= ((float) obj->bufferSize)) {
+        if ((obj->intervalSize + obj->intervalIn) <= ((double) obj->bufferSize)) {
 
             iWriteInt = (unsigned int) obj->iWrite;
 
-            if ((obj->iWrite + obj->intervalIn) <= ((float) obj->bufferSize)) {
+            if ((obj->iWrite + obj->intervalIn) <= ((double) obj->bufferSize)) {
 
                 iHop1 = 0;
                 iBuffer1 = iWriteInt;
@@ -170,10 +170,10 @@
 
             }
 
-            obj->intervalSize += (float) obj->intervalIn;
+            obj->intervalSize += (double) obj->intervalIn;
 
-            obj->iWrite += (float) obj->intervalIn;
-            obj->iWrite = fmod(obj->iWrite, (float) obj->bufferSize);
+            obj->iWrite += (double) obj->intervalIn;
+            obj->iWrite = fmod(obj->iWrite, (double) obj->bufferSize);
 
         }
 
@@ -184,10 +184,10 @@
         unsigned int iSample;
         unsigned int iReadFloor;
         unsigned int iReadCeil;
-        float yFloor;
-        float yCeil;
-        float yDelta;
-        float xDelta;
+        double yFloor;
+        double yCeil;
+        double yDelta;
+        double xDelta;
 
         unsigned int iSignal;
 
@@ -195,11 +195,11 @@
 
             for (iSample = 0; iSample < obj->hopSizeOut; iSample++) {
 
-                iReadFloor = (unsigned int) floorf(obj->iRead);
+                iReadFloor = (unsigned int) floor(obj->iRead);
                 iReadCeil = (iReadFloor + 1) % obj->bufferSize;
 
-                xDelta = obj->iRead - floorf(obj->iRead);
-                
+                xDelta = obj->iRead - floor(obj->iRead);
+
                 for (iSignal = 0; iSignal < obj->nSignals; iSignal++) {
 
                     yFloor = obj->array[iSignal][iReadFloor];
@@ -211,11 +211,11 @@
                 }
 
                 obj->iRead += obj->delta;
-                obj->iRead = fmod(obj->iRead, (float) obj->bufferSize);
+                obj->iRead = fmod(obj->iRead, (double) obj->bufferSize);
 
             }
 
-            obj->intervalSize -= (float) obj->intervalOut;
+            obj->intervalSize -= (double) obj->intervalOut;
 
         }
 
@@ -227,8 +227,8 @@
 
         rtnValue = 0;
 
-        if ((obj->intervalSize + obj->intervalIn) > ((float) obj->bufferSize)) {
-            
+        if ((obj->intervalSize + obj->intervalIn) > ((double) obj->bufferSize)) {
+
             rtnValue = 1;
 
         }
@@ -244,7 +244,7 @@
         rtnValue = 0;
 
         if (obj->intervalOut > obj->intervalSize) {
-            
+
             rtnValue = 1;
 
         }


### PR DESCRIPTION
After 20-25 minutes, the float is drifting causing audible audio artefacts when resampling from 16000 Hz to 44100 Hz.