### PR TITLE
Add return statements in thread start routines

### DIFF
--- a/src/aconnector/acon_categories.c
+++ b/src/aconnector/acon_categories.c
@@ -110,4 +110,5 @@
 
         }
 
+        return NULL;
     }

--- a/src/aconnector/acon_hops.c
+++ b/src/aconnector/acon_hops.c
@@ -110,4 +110,5 @@
 
         }
 
+        return NULL;
     }

--- a/src/aconnector/acon_pots.c
+++ b/src/aconnector/acon_pots.c
@@ -110,4 +110,5 @@
 
         }
 
+        return NULL;
     }

--- a/src/aconnector/acon_powers.c
+++ b/src/aconnector/acon_powers.c
@@ -110,4 +110,5 @@
 
         }
 
+        return NULL;
     }

--- a/src/aconnector/acon_spectra.c
+++ b/src/aconnector/acon_spectra.c
@@ -110,4 +110,5 @@
 
         }
 
+        return NULL;
     }

--- a/src/aconnector/acon_targets.c
+++ b/src/aconnector/acon_targets.c
@@ -109,4 +109,5 @@
 
         }
 
+        return NULL;
     }

--- a/src/aconnector/acon_tracks.c
+++ b/src/aconnector/acon_tracks.c
@@ -109,4 +109,5 @@
 
         }
 
+        return NULL;
     }

--- a/src/ainjector/ainj_targets.c
+++ b/src/ainjector/ainj_targets.c
@@ -96,5 +96,6 @@
 
         }
 
+        return NULL;
 
     }

--- a/src/amodule/amod_classify.c
+++ b/src/amodule/amod_classify.c
@@ -116,4 +116,5 @@
 
         }
 
+        return NULL;
     }

--- a/src/amodule/amod_istft.c
+++ b/src/amodule/amod_istft.c
@@ -110,4 +110,5 @@
 
         }
 
+        return NULL;
     }

--- a/src/amodule/amod_mapping.c
+++ b/src/amodule/amod_mapping.c
@@ -110,4 +110,5 @@
 
         }
 
+        return NULL;
     }

--- a/src/amodule/amod_noise.c
+++ b/src/amodule/amod_noise.c
@@ -110,4 +110,5 @@
 
         }
 
+        return NULL;
     }

--- a/src/amodule/amod_resample.c
+++ b/src/amodule/amod_resample.c
@@ -126,4 +126,5 @@
 
         }
 
+        return NULL;
     }

--- a/src/amodule/amod_ssl.c
+++ b/src/amodule/amod_ssl.c
@@ -111,4 +111,5 @@
 
         }
 
+        return NULL;
     }

--- a/src/amodule/amod_sss.c
+++ b/src/amodule/amod_sss.c
@@ -128,4 +128,5 @@
 
         }
 
+        return NULL;
     }

--- a/src/amodule/amod_sst.c
+++ b/src/amodule/amod_sst.c
@@ -116,4 +116,5 @@
 
         }
 
+        return NULL;
     }

--- a/src/amodule/amod_stft.c
+++ b/src/amodule/amod_stft.c
@@ -110,4 +110,5 @@
 
         }
 
+        return NULL;
     }

--- a/src/amodule/amod_volume.c
+++ b/src/amodule/amod_volume.c
@@ -110,4 +110,5 @@
 
         }
 
+        return NULL;
     }

--- a/src/asink/asnk_categories.c
+++ b/src/asink/asnk_categories.c
@@ -94,5 +94,6 @@
 
         // Close the sink
         snk_categories_close(obj->snk_categories);
+        return NULL;
 
     }

--- a/src/asink/asnk_hops.c
+++ b/src/asink/asnk_hops.c
@@ -94,5 +94,6 @@
 
         // Close the sink
         snk_hops_close(obj->snk_hops);
+        return NULL;
 
     }

--- a/src/asink/asnk_pots.c
+++ b/src/asink/asnk_pots.c
@@ -94,5 +94,6 @@
 
         // Close the sink
         snk_pots_close(obj->snk_pots);
+        return NULL;
 
     }

--- a/src/asink/asnk_powers.c
+++ b/src/asink/asnk_powers.c
@@ -94,5 +94,6 @@
 
         // Close the sink
         snk_powers_close(obj->snk_powers);
+        return NULL;
 
     }

--- a/src/asink/asnk_spectra.c
+++ b/src/asink/asnk_spectra.c
@@ -94,5 +94,6 @@
 
         // Close the sink
         snk_spectra_close(obj->snk_spectra);
+        return NULL;
 
     }

--- a/src/asink/asnk_tracks.c
+++ b/src/asink/asnk_tracks.c
@@ -94,5 +94,6 @@
 
         // Close the sink
         snk_tracks_close(obj->snk_tracks);
+        return NULL;
 
     }

--- a/src/asource/asrc_hops.c
+++ b/src/asource/asrc_hops.c
@@ -105,5 +105,6 @@
         msg_hops_out = amsg_hops_empty_pop(obj->out);
         msg_hops_zero(msg_hops_out);
         amsg_hops_filled_push(obj->out, msg_hops_out);
+        return NULL;
 
     }


### PR DESCRIPTION
All functions that are not void should return a value on every exit path.