### PR TITLE
Fix sprintf usage in format json functions

### DIFF
--- a/src/sink/snk_categories.c
+++ b/src/sink/snk_categories.c
@@ -336,32 +336,34 @@
     void snk_categories_process_format_text_json(snk_categories_obj * obj) {
 
         unsigned int iChannel;
+        int tmpBufferSize;
 
         obj->buffer[0] = 0x00;
+        tmpBufferSize = 0;
 
-        sprintf(obj->buffer,"%s{\n",obj->buffer);
-        sprintf(obj->buffer,"%s    \"timeStamp\": %llu,\n",obj->buffer,obj->in->timeStamp);
-        sprintf(obj->buffer,"%s    \"src\": [\n",obj->buffer);
+        tmpBufferSize += sprintf(obj->buffer + tmpBufferSize, "{\n");
+        tmpBufferSize += sprintf(obj->buffer + tmpBufferSize, "    \"timeStamp\": %llu,\n", obj->in->timeStamp);
+        tmpBufferSize += sprintf(obj->buffer + tmpBufferSize, "    \"src\": [\n");
 
         for (iChannel = 0; iChannel < obj->nChannels; iChannel++) {
 
-            switch(obj->in->categories->array[iChannel]) {
+            switch (obj->in->categories->array[iChannel]) {
 
-                case 0x01:
+            case 0x01:
 
-                    sprintf(obj->buffer,"%s        { \"category\": \"speech\" }",obj->buffer);
-
-                break;
-
-                case 0x00:
-
-                    sprintf(obj->buffer,"%s        { \"category\": \"nonspeech\" }",obj->buffer);
+                tmpBufferSize += sprintf(obj->buffer + tmpBufferSize, "        { \"category\": \"speech\" }");
 
                 break;
 
-                default:
+            case 0x00:
 
-                    sprintf(obj->buffer,"%s        { \"category\": \"undefined\" }",obj->buffer);
+                tmpBufferSize += sprintf(obj->buffer + tmpBufferSize, "        { \"category\": \"nonspeech\" }");
+
+                break;
+
+            default:
+
+                tmpBufferSize += sprintf(obj->buffer + tmpBufferSize, "        { \"category\": \"undefined\" }");
 
                 break;
 
@@ -369,16 +371,16 @@
 
             if (iChannel != (obj->nChannels - 1)) {
 
-                sprintf(obj->buffer,"%s,",obj->buffer);
+                tmpBufferSize += sprintf(obj->buffer + tmpBufferSize, ",");
 
             }
 
-            sprintf(obj->buffer,"%s\n",obj->buffer);
+            tmpBufferSize += sprintf(obj->buffer + tmpBufferSize, "\n");
 
         }
-        
-        sprintf(obj->buffer,"%s    ]\n",obj->buffer);
-        sprintf(obj->buffer,"%s}\n",obj->buffer);
+
+        tmpBufferSize += sprintf(obj->buffer + tmpBufferSize, "    ]\n");
+        tmpBufferSize += sprintf(obj->buffer + tmpBufferSize,"}\n");
 
         obj->bufferSize = strlen(obj->buffer);
 

--- a/src/sink/snk_categories.c
+++ b/src/sink/snk_categories.c
@@ -347,23 +347,23 @@
 
         for (iChannel = 0; iChannel < obj->nChannels; iChannel++) {
 
-            switch (obj->in->categories->array[iChannel]) {
+            switch(obj->in->categories->array[iChannel]) {
 
-            case 0x01:
+                case 0x01:
 
-                tmpBufferSize += sprintf(obj->buffer + tmpBufferSize, "        { \"category\": \"speech\" }");
-
-                break;
-
-            case 0x00:
-
-                tmpBufferSize += sprintf(obj->buffer + tmpBufferSize, "        { \"category\": \"nonspeech\" }");
+                    tmpBufferSize += sprintf(obj->buffer + tmpBufferSize, "        { \"category\": \"speech\" }");
 
                 break;
 
-            default:
+                case 0x00:
 
-                tmpBufferSize += sprintf(obj->buffer + tmpBufferSize, "        { \"category\": \"undefined\" }");
+                    tmpBufferSize += sprintf(obj->buffer + tmpBufferSize, "        { \"category\": \"nonspeech\" }");
+
+                break;
+
+                default:
+
+                    tmpBufferSize += sprintf(obj->buffer + tmpBufferSize, "        { \"category\": \"undefined\" }");
 
                 break;
 

--- a/src/sink/snk_pots.c
+++ b/src/sink/snk_pots.c
@@ -352,30 +352,32 @@
     void snk_pots_process_format_text_json(snk_pots_obj * obj) {
 
         unsigned int iPot;
+        int tmpBufferSize;
 
         obj->buffer[0] = 0x00;
+        tmpBufferSize = 0;
 
-        sprintf(obj->buffer,"%s{\n",obj->buffer);
-        sprintf(obj->buffer,"%s    \"timeStamp\": %llu,\n",obj->buffer,obj->in->timeStamp);
-        sprintf(obj->buffer,"%s    \"src\": [\n",obj->buffer);
+        tmpBufferSize += sprintf(obj->buffer + tmpBufferSize,"{\n");
+        tmpBufferSize += sprintf(obj->buffer + tmpBufferSize,"    \"timeStamp\": %llu,\n",obj->in->timeStamp);
+        tmpBufferSize += sprintf(obj->buffer + tmpBufferSize,"    \"src\": [\n");
 
         for (iPot = 0; iPot < obj->nPots; iPot++) {
 
-            sprintf(obj->buffer,"%s        { \"x\": %1.3f, \"y\": %1.3f, \"z\": %1.3f, \"E\": %1.3f }", obj->buffer, 
+            tmpBufferSize += sprintf(obj->buffer + tmpBufferSize,"        { \"x\": %1.3f, \"y\": %1.3f, \"z\": %1.3f, \"E\": %1.3f }",
                     obj->in->pots->array[iPot*4+0], obj->in->pots->array[iPot*4+1], obj->in->pots->array[iPot*4+2], obj->in->pots->array[iPot*4+3]);
 
             if (iPot != (obj->nPots - 1)) {
 
-                sprintf(obj->buffer,"%s,",obj->buffer);
+                tmpBufferSize += sprintf(obj->buffer + tmpBufferSize,",");
 
             }
 
-            sprintf(obj->buffer,"%s\n",obj->buffer);
+            tmpBufferSize += sprintf(obj->buffer + tmpBufferSize,"\n");
 
         }
         
-        sprintf(obj->buffer,"%s    ]\n",obj->buffer);
-        sprintf(obj->buffer,"%s}\n",obj->buffer);        
+        tmpBufferSize += sprintf(obj->buffer + tmpBufferSize,"    ]\n");
+        tmpBufferSize += sprintf(obj->buffer + tmpBufferSize,"}\n");
 
         obj->bufferSize = strlen(obj->buffer);
 

--- a/src/sink/snk_tracks.c
+++ b/src/sink/snk_tracks.c
@@ -341,17 +341,18 @@
     void snk_tracks_process_format_text_json(snk_tracks_obj * obj) {
 
         unsigned int iTrack;
+        int tmpBufferSize;
 
         obj->buffer[0] = 0x00;
+        tmpBufferSize = 0;
 
-        sprintf(obj->buffer,"%s{\n",obj->buffer);
-        sprintf(obj->buffer,"%s    \"timeStamp\": %llu,\n",obj->buffer,obj->in->timeStamp);
-        sprintf(obj->buffer,"%s    \"src\": [\n",obj->buffer);
+        tmpBufferSize += sprintf(obj->buffer + tmpBufferSize,"{\n");
+        tmpBufferSize += sprintf(obj->buffer + tmpBufferSize,"    \"timeStamp\": %llu,\n",obj->in->timeStamp);
+        tmpBufferSize += sprintf(obj->buffer + tmpBufferSize,"    \"src\": [\n");
 
         for (iTrack = 0; iTrack < obj->nTracks; iTrack++) {
 
-            sprintf(obj->buffer,"%s        { \"id\": %llu, \"tag\": \"%s\", \"x\": %1.3f, \"y\": %1.3f, \"z\": %1.3f, \"activity\": %1.3f }", 
-                    obj->buffer,
+            tmpBufferSize += sprintf(obj->buffer + tmpBufferSize,"        { \"id\": %llu, \"tag\": \"%s\", \"x\": %1.3f, \"y\": %1.3f, \"z\": %1.3f, \"activity\": %1.3f }",
                     obj->in->tracks->ids[iTrack],
                     obj->in->tracks->tags[iTrack],
                     obj->in->tracks->array[iTrack*3+0], 
@@ -361,16 +362,16 @@
 
             if (iTrack != (obj->nTracks - 1)) {
 
-                sprintf(obj->buffer,"%s,",obj->buffer);
+                tmpBufferSize += sprintf(obj->buffer + tmpBufferSize, ",");
 
             }
 
-            sprintf(obj->buffer,"%s\n",obj->buffer);
+            tmpBufferSize += sprintf(obj->buffer + tmpBufferSize, "\n");
 
         }
-        
-        sprintf(obj->buffer,"%s    ]\n",obj->buffer);
-        sprintf(obj->buffer,"%s}\n",obj->buffer);
+
+        tmpBufferSize += sprintf(obj->buffer + tmpBufferSize, "    ]\n");
+        tmpBufferSize += sprintf(obj->buffer + tmpBufferSize,"}\n");
 
         obj->bufferSize = strlen(obj->buffer);
 


### PR DESCRIPTION
hostnamectl:
```
	...
Operating System: Ubuntu 23.10
          Kernel: Linux 6.5.0-17-generic
    Architecture: x86-64
	...
```




lib version:
```
-- Found PkgConfig: /usr/bin/pkg-config (found version "1.8.1")
-- Checking for module 'fftw3f'
--   Found fftw3f, version 3.3.10
-- Checking for module 'alsa'
--   Found alsa, version 1.2.9
-- Checking for module 'libconfig'
--   Found libconfig, version 1.5
-- Checking for module 'libpulse-simple'
--   Found libpulse-simple, version 16.1
```




After i build odas and start, i see that *.json files only contain "}" strings(2251 in my case) like this:
```
}
}
}
}
}
}
```




How i build ODAS:
```bash
cd

# Before next apt-get's i added to the end of file "/etc/apt/sources.list" this line
# >deb http://cz.archive.ubuntu.com/ubuntu lunar main universe

sudo apt-get update
sudo apt-get install libfftw3-dev libconfig-dev libasound2-dev libgconf-2-4
sudo apt-get install cmake
sudo apt-get install -y build-essential libpulse-dev git

git clone https://github.com/introlab/odas.git

mkdir odas/build
cd odas/build

cmake ..
make
```




What exactly is the problem and why should you not do that ?
```
sprintf(buff, “%s %s”, buff, “some text”); - incorrect usage
https://stackoverflow.com/questions/1973572/can-the-input-and-output-strings-to-sprintf-be-the-same
https://stackoverflow.com/questions/21912061/strange-output-of-sprintf-whats-causing-it
https://pubs.opengroup.org/onlinepubs/9699919799/functions/sprintf.html
https://pvs-studio.com/en/docs/warnings/v541/
```




Files and functions affected:
```
odas/src/sink/snk_pots.c:snk_pots_process_format_text_json
odas/src/sink/snk_tracks.c:snk_tracks_process_format_text_json
odas/src/sink/snk_categories.c:snk_categories_process_format_text_json
```




After commit
Tested with config on three json variants - everything works fine:
```
ssl:
potential: {
    format = "json";

    interface: {
        type = "file";
        path = "ssl.potenital.json";
    };
};

sst:
tracked: {
    format = "json";

    interface: {
        type = "file";
        path = "sst.tracked.json";
    };
};

classify:
category: {
    format = "json";

    interface: {
        type = "file";
        path = "classify.category.json"
    }
}
```