### PR TITLE
- Added support to read from stdin if the file source is "stdin"

### DIFF
--- a/src/source/src_hops.c
+++ b/src/source/src_hops.c
@@ -154,7 +154,13 @@ void src_hops_open(src_hops_obj * obj) {
 
 void src_hops_open_interface_file(src_hops_obj * obj) {
 
-    obj->fp = fopen(obj->interface->fileName, "rb");
+	if (strcmp(obj->interface->fileName, "stdin") == 0)
+	{
+		obj->fp = freopen(NULL, "rb", stdin);
+	}else
+	{
+    	obj->fp = fopen(obj->interface->fileName, "rb");
+	}
 
     if (obj->fp == NULL) {
         printf("Cannot open file %s\n", obj->interface->fileName);


### PR DESCRIPTION
I wanted to playback recordings of raw channels so I could easily iterate and compare results in my software. I just use `cat` to pipe to `pv` to throttle the playback at an approximate real time speed through to `stdin` for ODAS using the provided PR.

```
cat rawdump-48k32bit8chan | pv -L 1500k | ./build/odas/bin/odaslive -c odas-config/stdin-subbi-postfilter.cfg
```