### PR TITLE
- Added "dropped" sources list to JSON output

### DIFF
--- a/include/odas/signal/track.h
+++ b/include/odas/signal/track.h
@@ -37,6 +37,7 @@
 
         unsigned int nTracks;
         unsigned long long * ids;
+        unsigned long long * dropped;
         char ** tags;
         float * array;
         float * activity;

--- a/src/module/mod_sst.c
+++ b/src/module/mod_sst.c
@@ -1104,11 +1104,13 @@
            
                 memset(obj->out->tracks->array, 0x00, sizeof(float) * obj->out->tracks->nTracks * 3);
                 memset(obj->out->tracks->ids, 0x00, sizeof(unsigned long long) * obj->out->tracks->nTracks);
+				memset(obj->out->tracks->dropped, 0x00, sizeof(unsigned long long) * obj->out->tracks->nTracks);
                 memset(obj->out->tracks->activity, 0x00, sizeof(float) * obj->out->tracks->nTracks);
 
                 for (iTrackMax = 0; iTrackMax < obj->nTracksMax; iTrackMax++) {
 
                     strcpy(obj->out->tracks->tags[iTrackMax], "");
+					obj->out->tracks->dropped[iTrackMax] = obj->idsRemoved[iTrackMax];
 
                     if (obj->ids[iTrackMax] != 0) {
 

--- a/src/signal/track.c
+++ b/src/signal/track.c
@@ -41,6 +41,8 @@
         memset(obj->array, 0x00, sizeof(float) * 3 * nTracks);
         obj->ids = (unsigned long long *) malloc(sizeof(unsigned long long) * nTracks);
         memset(obj->ids, 0x00, sizeof(unsigned long long) * nTracks);
+        obj->dropped = (unsigned long long *) malloc(sizeof(unsigned long long) * nTracks);
+        memset(obj->dropped, 0x00, sizeof(unsigned long long) * nTracks);
 
         obj->tags = (char **) malloc(sizeof(char *) * nTracks);
 
@@ -64,6 +66,7 @@
 
         free((void *) obj->array);
         free((void *) obj->ids);
+        free((void *) obj->dropped);
 
         for (iTrack = 0; iTrack < obj->nTracks; iTrack++) {
             free((void *) obj->tags[iTrack]);
@@ -87,6 +90,8 @@
         memcpy(clone->array, obj->array, sizeof(float) * 3 * obj->nTracks);
         clone->ids = (unsigned long long *) malloc(sizeof(unsigned long long) * obj->nTracks);
         memcpy(clone->ids, obj->ids, sizeof(unsigned long long) * obj->nTracks);
+        clone->dropped = (unsigned long long *) malloc(sizeof(unsigned long long) * obj->nTracks);
+        memcpy(clone->dropped, obj->dropped, sizeof(unsigned long long) * obj->nTracks);
 
         clone->tags = (char **) malloc(sizeof(char *) * obj->nTracks);
 
@@ -111,6 +116,7 @@
         dest->nTracks = src->nTracks;
         memcpy(dest->array, src->array, sizeof(float) * 3 * src->nTracks);
         memcpy(dest->ids, src->ids, sizeof(unsigned long long) * src->nTracks);
+        memcpy(dest->dropped, src->dropped, sizeof(unsigned long long) * src->nTracks);
         
         for (iTrack = 0; iTrack < src->nTracks; iTrack++) {
 
@@ -128,6 +134,7 @@
 
         memset(obj->array, 0x00, sizeof(float) * 3 * obj->nTracks);
         memset(obj->ids, 0x00, sizeof(unsigned long long) * obj->nTracks);       
+        memset(obj->dropped, 0x00, sizeof(unsigned long long) * obj->nTracks);       
 
         for (iTrack = 0; iTrack < obj->nTracks; iTrack++) {
             
@@ -154,5 +161,8 @@
                    obj->activity[iTrack]);
             
         }
+        for (iTrack = 0; iTrack < obj->nTracks; iTrack++) {
 
+            printf("Dropped (%04llu)\n", obj->dropped[iTrack]);
+        }
     }

--- a/src/sink/snk_tracks.c
+++ b/src/sink/snk_tracks.c
@@ -341,6 +341,9 @@
     void snk_tracks_process_format_text_json(snk_tracks_obj * obj) {
 
         unsigned int iTrack;
+		int addedDroppedEntry;
+		
+		addedDroppedEntry = 0;
 
         obj->buffer[0] = 0x00;
 
@@ -368,6 +371,25 @@
             sprintf(obj->buffer,"%s\n",obj->buffer);
 
         }
+        
+        sprintf(obj->buffer,"%s    ],\n",obj->buffer);
+        sprintf(obj->buffer,"%s    \"dropped\": [\n",obj->buffer);
+
+        for (iTrack = 0; iTrack < obj->nTracks; iTrack++)
+		{
+			if(obj->in->tracks->dropped[iTrack]!=0)
+			{
+				if(addedDroppedEntry == 1)
+				{
+					sprintf(obj->buffer,"%s,",obj->buffer);
+				}
+				sprintf(obj->buffer,"%s        { \"id\": %llu }", 
+						obj->buffer, obj->in->tracks->dropped[iTrack]);
+				addedDroppedEntry = 1;
+			}
+		}
+
+    	sprintf(obj->buffer,"%s\n",obj->buffer);
         
         sprintf(obj->buffer,"%s    ]\n",obj->buffer);
         sprintf(obj->buffer,"%s}\n",obj->buffer);


### PR DESCRIPTION
I found it useful to receive tracking information about dropped sources via `sst`. This PR updates the output to include:
```
dropped: [
]
```
after `src`.

This resulted in more reliable downstream tracking in my application.

I'm happy to make this optional if it is would be too disruptive as default.